### PR TITLE
Protect `readLine()` against DoS

### DIFF
--- a/app/src/main/java/org/lsposed/manager/ui/dialog/FlashDialogBuilder.java
+++ b/app/src/main/java/org/lsposed/manager/ui/dialog/FlashDialogBuilder.java
@@ -19,6 +19,7 @@
 
 package org.lsposed.manager.ui.dialog;
 
+import io.github.pixee.security.BoundedLineReader;
 import static org.lsposed.manager.App.TAG;
 
 import android.content.Context;
@@ -119,7 +120,7 @@ public class FlashDialogBuilder extends BlurBehindDialogBuilder {
             var inputStream = new ParcelFileDescriptor.AutoCloseInputStream(readSide);
             var reader = new BufferedReader(new InputStreamReader(inputStream));
 
-            for (var line = ""; line != null; line = reader.readLine()) {
+            for (var line = ""; line != null; line = BoundedLineReader.readLine(reader, 5_000_000)) {
                 if (line.length() > 0) {
                     var showLine = line + "\n";
                     view.post(() -> {

--- a/daemon/src/main/java/org/lsposed/lspd/cli/Main.java
+++ b/daemon/src/main/java/org/lsposed/lspd/cli/Main.java
@@ -9,6 +9,7 @@ import android.os.RemoteException;
 import android.os.ServiceManager;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import io.github.pixee.security.BoundedLineReader;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -75,7 +76,7 @@ class LogCommand implements Callable<Integer> {
         while (true) {
             String sLine;
             try {
-                sLine = br.readLine();
+                sLine = BoundedLineReader.readLine(br, 5_000_000);
             } catch (IOException ioe) { break; }
             if (sLine == null) {
                 if (bFollow) {

--- a/daemon/src/main/java/org/lsposed/lspd/service/ConfigFileManager.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/ConfigFileManager.java
@@ -19,6 +19,7 @@
 
 package org.lsposed.lspd.service;
 
+import io.github.pixee.security.BoundedLineReader;
 import static org.lsposed.lspd.service.ServiceManager.TAG;
 import static org.lsposed.lspd.service.ServiceManager.toGlobalNamespace;
 
@@ -366,7 +367,7 @@ public class ConfigFileManager {
         try (var in = apkFile.getInputStream(initEntry)) {
             var reader = new BufferedReader(new InputStreamReader(in));
             String name;
-            while ((name = reader.readLine()) != null) {
+            while ((name = BoundedLineReader.readLine(reader, 5_000_000)) != null) {
                 name = name.trim();
                 if (name.isEmpty() || name.startsWith("#")) continue;
                 names.add(name);


### PR DESCRIPTION
This change hardens all [`BufferedReader#readLine()`](https://docs.oracle.com/javase/8/docs/api/java/io/BufferedReader.html#readLine--) operations against memory exhaustion.

There is no way to call `readLine()` safely since it is, by its nature, a read that must be terminated by the stream provider. Furthermore, a stream of data provided by an untrusted source could lead to a denial of service attack, as attackers can provide an infinite stream of bytes until the process runs out of memory.

Fixing it is straightforward using an API which limits the amount of expected characters to some sane limit. This is what our changes look like:

```diff
+ import io.github.pixee.security.BoundedLineReader;
  ...
  BufferedReader reader = getReader();
- String line = reader.readLine(); // unlimited read, can lead to DoS
+ String line = BoundedLineReader.readLine(reader, 5_000_000); // limited to 5MB
```


:x: The following packages couldn't be installed automatically, probably because the dependency manager is unsupported. Please install them manually:
<details open>
    <summary>Gradle</summary>

    dependencies {
      implementation("io.github.pixee:java-security-toolkit:1.2.0")
    }

</details>

<details>
    <summary>Maven</summary>

    <dependencies>
      <dependency>
        <groupId>io.github.pixee</groupId>
        <artifactId>java-security-toolkit</artifactId>
        <version>1.2.0</version>
      </dependency>
    <dependencies>

</details>

<details>
  <summary>More reading</summary>

  * [https://vulncat.fortify.com/en/detail?id=desc.dataflow.abap.denial_of_service](https://vulncat.fortify.com/en/detail?id=desc.dataflow.abap.denial_of_service)
  * [https://cwe.mitre.org/data/definitions/400.html](https://cwe.mitre.org/data/definitions/400.html)
</details>


🧚🤖  Powered by Pixeebot  

[Feedback](https://ask.pixee.ai/feedback) | [Community](https://pixee-community.slack.com/signup#/domain-signup) | [Docs](https://docs.pixee.ai/) | Codemod ID: pixee:java/limit-readline ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2Fmywalkb-LSPosed_mod%7Caeafbcbd4a2a8cc8bf6c8583e6e8879cf087c0c8)


<!--{"type":"DRIP","codemod":"pixee:java/limit-readline"}-->