### PR TITLE
Make it possible to add system/0 to the scope from the CLI and add info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ We use our own module repository. We welcome developers to submit modules to our
 
 - [LSPosed Module Repository](https://github.com/Xposed-Modules-Repo)
 
+## Building locally
+- Clone [libxposed:api](https://github.com/libxposed/api/commit/54582730315ba4a3d7cfaf9baf9d23c419e07006) and [libxposed:service](https://github.com/libxposed/service)
+- Execute `./gradlew publishToMavenLocal` so these dependencies can directly be referenced by this project
+
 ## Translation Contributing
 
 You can contribute translation [here](https://crowdin.com/project/lsposedmod).

--- a/daemon/src/main/java/org/lsposed/lspd/cli/Main.java
+++ b/daemon/src/main/java/org/lsposed/lspd/cli/Main.java
@@ -282,26 +282,26 @@ class SetScopeCommand implements Callable<Integer> {
             objArgs.bSet = true;
         }
 
-        boolean bAndroidExist = false;
+        boolean bAndroidOrSystemExist = false;
         if (objArgs.bSet) {
             var lstScope = manager.getModuleScope(moduleName);
             if (lstScope == null) {
                 System.err.println(manager.getLastErrorMsg());
                 return ERRCODES.SET_SCOPE.ordinal();
             }
-            bAndroidExist = Utils.checkPackageInScope("android", lstScope);
+            bAndroidOrSystemExist = Utils.checkPackageInScope("android", lstScope) | Utils.checkPackageInScope("system", lstScope);
         }
 
         for(var scope : scopes) {
             if (Utils.validPackageNameAndUserId(manager, scope.packageName, scope.userId)) {
-                if (scope.packageName.equals("android")) {
+                if (scope.packageName.equals("android") || scope.packageName.equals("system")) {
                     bMsgReboot = true;
                 }
             } else if (!bIgnore) {
                 throw new RuntimeException("Error: " + scope.packageName + (scope.userId < 0? "" : ("/" + scope.userId)) + " is not a valid package name");
             }
         }
-        if (bAndroidExist && !bMsgReboot) { // if android is removed with setcommand reboot is required
+        if (bAndroidOrSystemExist && !bMsgReboot) { // if android or system is removed with setcommand reboot is required
             bMsgReboot = true;
         }
         if (bMsgReboot) {

--- a/daemon/src/main/java/org/lsposed/lspd/cli/Utils.java
+++ b/daemon/src/main/java/org/lsposed/lspd/cli/Utils.java
@@ -2,6 +2,7 @@ package org.lsposed.lspd.cli;
 
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.os.Parcel;
 import android.os.RemoteException;
 
 import org.lsposed.lspd.ICLIService;
@@ -35,6 +36,16 @@ public class Utils {
         for (var packageInfo: packages) {
             int userid = packageInfo.applicationInfo.uid / 100000;
             packagesMap.put(packageInfo.packageName + "|" + userid, packageInfo);
+
+            if ("android".equals(packageInfo.packageName)) {
+                var p = Parcel.obtain();
+                packageInfo.writeToParcel(p, 0);
+                p.setDataPosition(0);
+                PackageInfo system = PackageInfo.CREATOR.createFromParcel(p);
+                system.packageName = "system";
+                system.applicationInfo.packageName = system.packageName;
+                packagesMap.put(system.packageName + "|" + userid, system);
+            }
         }
     }
 


### PR DESCRIPTION
It's currently not possible to add system/0 to the scope from the CLI because we don't do the same workaround there which is done in the UI (adding "system" to the list of available packages manually when we encounter the "android" package).

We also want to prompt a reboot in this case.

I struggled to build this till I realized that I needed to use a specific commit of libxposed:api, I added this information to the readme.